### PR TITLE
Execute `npm install` before `grunt dev`.

### DIFF
--- a/openattic-dev/ubuntu_16.04/entrypoint.sh
+++ b/openattic-dev/ubuntu_16.04/entrypoint.sh
@@ -63,6 +63,7 @@ function setup_oa {
   a2enconf openattic
   systemctl restart apache2
   cd /srv/openattic/webui
+  npm install
   grunt dev
 }
 


### PR DESCRIPTION
This change prevents the error "Fatal error: Unable to find local grunt.".

Signed-off-by: Ricardo Marques <ricardo.a.s.marques@gmail.com>